### PR TITLE
bower-map not parsing less and sass files

### DIFF
--- a/automation/grunt/configuration/bower.js
+++ b/automation/grunt/configuration/bower.js
@@ -43,7 +43,7 @@ module.exports = {
         less: {
             options: {
                 dest: '<%= settings.source.less %>/<%= settings.vendorPath %>',
-                extensions: ['css'],
+                extensions: ['less','css'],
                 map: {
                     'normalize-css/normalize.css': 'normalize.less'
                 }
@@ -52,7 +52,7 @@ module.exports = {
         sass: {
             options: {
                 dest: '<%= settings.source.sass %>/<%= settings.vendorPath %>',
-                extensions: ['css'],
+                extensions: ['sass','css'],
                 map: {
                     'normalize-css/normalize.css': '_normalize.scss'
                 }


### PR DESCRIPTION
The bower-map isn't parsing and copying less and sass files in the bower.js files if main is declared.
